### PR TITLE
Update camera.py

### DIFF
--- a/visca_over_ip/camera.py
+++ b/visca_over_ip/camera.py
@@ -45,7 +45,7 @@ class Camera:
         terminator = b'\xff'
 
         payload_bytes = preamble + bytearray.fromhex(command_hex) + terminator
-        payload_length = len(preamble + payload_bytes + terminator).to_bytes(2, 'big')
+        payload_length = len(payload_bytes).to_bytes(2, 'big')
 
 
         exception = None


### PR DESCRIPTION
preamble and terminator were getting double counted in payload_length, causing an incorrect payload length and cameras would not respond to invalid message.