### PR TITLE
Connect using system selected local port

### DIFF
--- a/visca_over_ip/camera.py
+++ b/visca_over_ip/camera.py
@@ -21,7 +21,8 @@ class Camera:
         """
         self._location = (ip, port)
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # for UDP stuff
-        self._sock.bind(('', port))
+        self._sock.bind(('', 0))
+        self._port = self._sock.getsockname()[1]  
         self._sock.settimeout(0.1)
 
         self.num_missed_responses = 0


### PR DESCRIPTION
Rather than using the port number from the camera end pass the symbolic value 0 in as the port number. This allows the system to choose any available port number to connect on. The socket can then be queried to get the actual port number.

This change allows multiple cameras to be active at the same time as they are now using system selected free local port numbers.