### PR TITLE
Refactor: Identify and address initial issues in Camera classes

### DIFF
--- a/visca_over_ip/caching_camera.py
+++ b/visca_over_ip/caching_camera.py
@@ -8,10 +8,18 @@ class CachingCamera(Camera):
     def __init__(self, ip, port=52381):
         super().__init__(ip, port)
 
+        initial_focus_mode = None
+        try:
+            initial_focus_mode = super().get_focus_mode()
+        except ViscaException as e:
+            print(f"Warning: Could not fetch initial focus mode for CachingCamera: {e}")
+            # The camera might be offline or an error occurred.
+            # initial_focus_mode remains None.
+
         self.state = {
-            'focus_mode': super().get_focus_mode(),
-            'pan_tilt_stop': False,
-            'zoom_stop': False
+            'focus_mode': initial_focus_mode,
+            'pan_tilt_stop': False, # Assuming camera is not actively panning/tilting on init
+            'zoom_stop': False      # Assuming camera is not actively zooming on init
         }
 
     def get_focus_mode(self) -> str:


### PR DESCRIPTION
This commit includes several improvements and fixes to the visca_over_ip Camera and CachingCamera classes:

- Improved `Camera.__init__` error handling: Re-raises `ViscaException` if clearing the camera's interface socket fails during initialization.
- Refined `Camera.reset_sequence_number`: Ensures client-side sequence number is reset only if a confirmation response is received from the camera.
- Fixed `Camera.get_focus_mode()`: Corrected error handling for unknown or malformed responses, removing an unreachable code path.
- Strengthened `CachingCamera.__init__` resilience: The constructor now handles potential `ViscaException` when fetching the initial focus mode, allowing the object to be created by defaulting `focus_mode` to `None` and printing a warning.
- Added missing docstrings: Provided documentation for several public methods in `camera.py` related to adjusting gain, shutter, iris, brightness, exposure, and aperture.

Potential Issue Noted:
During the addition of docstrings, I observed that the methods `increase_white_balance_temperature`, `decrease_white_balance_temperature`, and `reset_white_balance_temperature` in `camera.py` use VISCA commands identical to those for red gain adjustment. This is likely a bug and requires further investigation to ensure correct camera operation for white balance temperature.